### PR TITLE
Fix compile errors on of0.9.3 to accomodate for new mouse events and …

### DIFF
--- a/src/ofxSplineTool.cpp
+++ b/src/ofxSplineTool.cpp
@@ -95,7 +95,7 @@ void ofxSplineTool::update() {
 			path.curveTo(cur);
 		}
 		path.curveTo(controlPoints.back());
-		vector<ofPolyline>& outline = path.getOutline();
+		vector<ofPolyline> outline = path.getOutline();
 		if(!outline.empty()) {
 			ofPolyline& pathPolyline = outline[0];
 			for(int i = 0; i < pathPolyline.size(); i++) {
@@ -273,6 +273,18 @@ void ofxSplineTool::updateMouse(ofMouseEventArgs& args) {
 			}
 		}
 	}
+}
+
+void ofxSplineTool::mouseEntered(ofMouseEventArgs& args) {
+	updateMouse(args);
+}
+
+void ofxSplineTool::mouseExited(ofMouseEventArgs& args) {
+	updateMouse(args);
+}
+
+void ofxSplineTool::mouseScrolled(ofMouseEventArgs& args) {
+	updateMouse(args);
 }
 
 void ofxSplineTool::mouseMoved(ofMouseEventArgs& args) {

--- a/src/ofxSplineTool.h
+++ b/src/ofxSplineTool.h
@@ -25,6 +25,9 @@ public:
 	
 	// these are only used internally
 	ofxSplineTool();
+	void mouseEntered(ofMouseEventArgs& args);
+	void mouseExited(ofMouseEventArgs& args);
+	void mouseScrolled(ofMouseEventArgs& args);
 	void mouseMoved(ofMouseEventArgs& args);
 	void mousePressed(ofMouseEventArgs& args);
 	void mouseDragged(ofMouseEventArgs& args);


### PR DESCRIPTION
…an invalid cast

Just updated so that it works with oF 0.9.3.

thanks for the awesome spline manager class!